### PR TITLE
Distance based shelters

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -12,7 +12,8 @@ blocked((time, stack) => {
 
 /* Setup constants from environment variable parameters */
 const dataURL = process.env.DATA_URL;
-const nSheltersToFind = process.env.nSheltersToFind || 4;
+const mileRadius = process.env.MILE_RADIUS || 30;
+const nSheltersToFind = process.env.nSheltersToFind || 12;
 
 /* Setup DataUpdater to periodically retrieve new location data */
 let locationData = new Map(); // actually fetched at server startup
@@ -21,7 +22,7 @@ const updater = new DataUpdater(dataURL);
 
 /* Setup SheltersFinder with dummy locationData */
 import SheltersFinder from './shelters_finder';
-const sheltersFinder = new SheltersFinder(locationData, nSheltersToFind);
+const sheltersFinder = new SheltersFinder(locationData, mileRadius, nSheltersToFind);
 
 /* Handle update event on the DataUpdater */
 updater.on('update', (data) => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,7 +12,7 @@ blocked((time, stack) => {
 
 /* Setup constants from environment variable parameters */
 const dataURL = process.env.DATA_URL;
-const mileRadius = process.env.MILE_RADIUS || 30;
+const nSheltersToFind = process.env.nSheltersToFind || 4;
 
 /* Setup DataUpdater to periodically retrieve new location data */
 let locationData = new Map(); // actually fetched at server startup
@@ -21,7 +21,7 @@ const updater = new DataUpdater(dataURL);
 
 /* Setup SheltersFinder with dummy locationData */
 import SheltersFinder from './shelters_finder';
-const sheltersFinder = new SheltersFinder(locationData, mileRadius);
+const sheltersFinder = new SheltersFinder(locationData, nSheltersToFind);
 
 /* Handle update event on the DataUpdater */
 updater.on('update', (data) => {

--- a/lib/shelters_finder.js
+++ b/lib/shelters_finder.js
@@ -11,9 +11,9 @@ export default class SheltersFinder {
    * @param {number} mileRadius - the mile radius to use when finding nearby shelters
    * @returns {SheltersFinder} - the created SheltersFinder instance
    */
-  constructor (locationData, mileRadius) {
+  constructor (locationData, nSheltersToFind) {
     this.locationData = locationData;
-    this.mileRadius = mileRadius;
+    this.nSheltersToFind = nSheltersToFind;
   }
 
   /**
@@ -34,7 +34,7 @@ export default class SheltersFinder {
     }
     let test_zip_info = zipcodes.lookup(sentZipCodes[0]);
     let test_zip = new LatLon(test_zip_info.latitude, test_zip_info.longitude);
-    let closest_shelters = this.findClosestNShelters(test_zip, 3);
+    let closest_shelters = this.findClosestNShelters(test_zip, this.nSheltersToFind);
     const messages = this.buildReplyFromShelterList(closest_shelters);
     return messages;
   }
@@ -90,132 +90,6 @@ export default class SheltersFinder {
   }
 
   /**
-   * Get all zip codes with known shelters in them
-   * @returns {Array<string>} - the array of zip codes
-   */
-  zipCodesWithShelters () {
-    return Array.from(this.locationData.keys());
-  }
-
-  /**
-   * Augment the zipcodes with zip information and zips in radius
-   * @param {Array<string>} zips - the array of zipcodes to augment
-   * @returns {Array<Object>} - the array of augmented zipcodes
-   */
-  augmentLookupZipCodes (zips) {
-    return zips.map((zip) => {
-      const zipInfo = zipcodes.lookup(zip);
-      return {
-        zip: zipInfo.zip,
-        info: zipInfo,
-        latlon: new LatLon(zipInfo.latitude, zipInfo.longitude),
-        zipsInMileRadius: zipcodes.radius(zipInfo.zip, this.mileRadius)
-      };
-    });
-  }
-
-  /**
-   * Compute the shelters found in the known zip codes from the lookups
-   * @param {Array<Object>} lookupZipCodes - the zipcodes to perform the lookup with
-   * @param {Array<Object>} knownZipCodes - the known zipcodes among the shelters
-   * @returns {Array<Object>} - the array of shelters found from the lookup
-   */
-  computeFoundShelters (lookupZipCodes, knownZipCodes) {
-    let foundShelters = [];
-    lookupZipCodes.forEach((z) => {
-      knownZipCodes.forEach((known) => {
-        if (z.zipsInMileRadius.indexOf(known.toString()) >= 0) {
-          foundShelters.push(known.toString());
-        }
-      });
-    });
-    return foundShelters;
-  }
-
-  /**
-   * Augment the shelter record with distance from lookups, whether its
-   * in the radius from the lookups, and with the message segment
-   * @param {Object} shelterRecord - the shelter record object
-   * @param {Array<Object>} lookupZipCodes - the array of lookups
-   * @returns {Array<Object>} - the augmented shelter record
-   */
-  augmentShelterRecord (shelterRecord, lookupZipCodes) {
-    const { shelter, address, phone } = shelterRecord;
-    const shelterLatLon = new LatLon(shelterRecord.latitude, shelterRecord.longitude);
-    const shelterDistancesFromLookupZips = Array.from(
-      lookupZipCodes.map((zip) => {
-        return zip.latlon.distanceTo(shelterLatLon);
-      })
-    );
-    const zipInMileRadiusFromShelter = Array.from(
-      lookupZipCodes.map((zip) => {
-        return zip.zipsInMileRadius.includes(shelterRecord.zip);
-      })
-    );
-    const distances = {};
-    const inRadius = {};
-    for (let idx in lookupZipCodes) {
-      const zip = lookupZipCodes[idx].zip;
-      distances[zip] = shelterDistancesFromLookupZips[idx];
-      inRadius[zip] = zipInMileRadiusFromShelter[idx];
-    }
-    return {
-      ...shelterRecord,
-      distances: distances,
-      inRadius: inRadius,
-      message: `\n\n${shelter}\n${address}${phone ? `\n${phone}` : ''}`
-    };
-  }
-
-  /**
-   * Collect the shelters for the array of zip codes into an Array
-   * @param {Array<Object>} foundShelters - the shelters to be collected
-   * @param {Array<Object>} lookupZipCodes - the augmented lookup zips
-   * @returns {Array<Object>} - the collected arrray of all relevant shelters
-   */
-  collectShelters (foundShelters, lookupZipCodes) {
-    let sheltersArray = [];
-    for (let zip of foundShelters) {
-      const loc = this.locationData.get(zip);
-      if (loc) {
-        const shelters = Array.from(loc);
-        sheltersArray = sheltersArray.concat(
-          shelters.map(
-            (shelterRecord) => {
-              return this.augmentShelterRecord(shelterRecord, lookupZipCodes)
-            }
-          )
-        );
-      } else {
-        console.warn(`Unexpected missing zip: ${zip}`);
-      }
-    }
-    return sheltersArray;
-  }
-
-  /**
-   * Return the array of shelters in radius, filtering out those not
-   * @param {Array<Object>} shelters - the array of shelters
-   * @param {string} lookupZip - the lookup index for the radius value
-   * @returns {Array<Object>} - the filtered array of shelters
-   */
-  getInRadiusShelters (shelters, lookupZip) {
-    return shelters.filter((sh, _i, _a, k = lookupZip) => sh.inRadius[k]);
-  }
-
-  /**
-   * Return the array of shelters sorted by distance ascending
-   * @param {Array<Object>} shelters - the array of shelters
-   * @param {string} lookupZip - the lookup zipcode for the distance value
-   * @returns {Array<Object>} - the sorted array of shelters
-   */
-  sortSheltersByDistance (shelters, lookupZip) {
-    return shelters.sort((a, b, k = lookupZip) =>
-      a.distances[k] - b.distances[k]
-    );
-  }
-
-  /**
    * Truncate the array of shelters to the amount specified
    * @param {Array<Object>} shelters - the array of shelters
    * @param {number} amount - the number of shelters to return
@@ -223,53 +97,6 @@ export default class SheltersFinder {
    */
   truncateShelterList (shelters, amount) {
     return shelters.slice(0, amount);
-  }
-
-  /**
-   * Filter, sort and truncate the list of shelters per lookup zipcode
-   * @param {Array<Object>} shelters - the array of augmented shelter records
-   * @param {Array<Object>} lookups - the array of augmented lookup zipcodes
-   * @param {number} sheltersPerLookup - the number of shelters to return per lookup zipcode
-   * @returns {Array<Object>} - the filtered, sorted and truncated array
-   */
-  sortedShelterListsByLookupZip (shelters, lookups, sheltersPerLookup) {
-    const results = {};
-    const n = sheltersPerLookup;
-    lookups.forEach((zip) => {
-      const filtered = this.getInRadiusShelters(shelters, zip);
-      const sorted = this.sortSheltersByDistance(filtered, zip);
-      const truncated = this.truncateShelterList(sorted, n);
-      results[zip] = truncated;
-    });
-    return results;
-  }
-
-  /**
-   * Construct messages from sorted shelter lists by lookup zipcode
-   * @param {Object} sorts - the object of sorted shelter lists keyed by lookup zipcode
-   * @returns {Array<string>} - the array of messages
-   */
-  buildMessages (sorts) {
-    const messages = [];
-    const milesToMeters = 1609.344, metersToMiles = 1.0 / milesToMeters;
-    for (let key in sorts) {
-      const sheltersSort = sorts[key];
-      const zipcode = key;
-      let resultString = `Found ${sheltersSort.length} shelters near ${zipcode}:`;
-      for (let shelter of sheltersSort) {
-        let dist = metersToMiles * shelter.distances[key];
-        dist = (dist < 1.0 ? Math.ceil(dist * 10) / 10 : Math.ceil(dist));
-        const msg = shelter.message +
-          `\n${dist < 1 ? 'Under 1' : `About ${dist}`}mi away`;
-        if ((resultString + msg).length > 800) {
-          messages.push(resultString);
-          resultString = '';
-        }
-        resultString += msg;
-      }
-      if (resultString.length > 0) { messages.push(resultString) }
-    }
-    return messages;
   }
 
   /**
@@ -326,25 +153,3 @@ export default class SheltersFinder {
      return `\n${shelter}\n${address}${phone ? `\n${phone}` : ''}`;
   }
 }
-
-// Helper functions
-export const _dedupeArray = function (arr, key) {
-  let a = _deepCopyArray(arr).reverse();
-  a = a.filter(function (e, i, a) {
-    const testVal = e[key];
-    return a.slice(i + 1).findIndex((o) => o[key] === testVal) === -1;
-  });
-  return a.reverse();
-};
-
-export const _deepCopyArray = function (o) {
-  let output, v, key;
-  output = Array.isArray(o) ? [] : (o == null ? null : {});
-  for (key in o) {
-    if (o.hasOwnProperty(key)) {
-      v = o[key];
-      output[key] = (typeof v === 'object') ? _deepCopyArray(v) : v;
-    }
-  }
-  return output;
-};

--- a/lib/shelters_finder.js
+++ b/lib/shelters_finder.js
@@ -32,18 +32,61 @@ export default class SheltersFinder {
     if(sentZipCodes.length == 0) {
       return ['Sorry, I couldn\'t find any ZIP codes in your text message. Please try again.',];
     }
-    const knownZipCodes = this.zipCodesWithShelters();
-    const lookupZipCodes = this.augmentLookupZipCodes(sentZipCodes);
-    let foundShelters = this.computeFoundShelters(lookupZipCodes, knownZipCodes);
-    if (foundShelters.length == 0) {
-      return [`Sorry, I don't know about any shelters near ${sentZipCodes.join(' or ')}. Please try again later!`,];
-    }
-    let sheltersArray = this.collectShelters(foundShelters, lookupZipCodes);
-    sheltersArray = _dedupeArray(sheltersArray, 'shelterIndex');
-
-    const sorts = this.sortedShelterListsByLookupZip(sheltersArray, lookupZipCodes.map((z) => z.zip), 3);
-    const messages = this.buildMessages(sorts);
+    let test_zip_info = zipcodes.lookup(sentZipCodes[0]);
+    let test_zip = new LatLon(test_zip_info.latitude, test_zip_info.longitude);
+    let closest_shelters = this.findClosestNShelters(test_zip, 3);
+    const messages = this.buildReplyFromShelterList(closest_shelters);
     return messages;
+  }
+
+  /**
+   * Get shelters by distance to currentPoint
+   * @param {LatLon} currentPoint - the point to find shelters nearest to
+   * @param {number} maxShelters - maximum number of shelters to return
+   * @returns {Array<Object>} - the array of shelters
+  */
+  findClosestNShelters (currentPoint, maxShelters) {
+    let shelters_with_distances = this.getShelterDistances(currentPoint);
+    let sorted_shelters = shelters_with_distances.sort(function(a, b) {
+      return a.distance - b.distance;
+    })
+    return this.truncateShelterList(sorted_shelters, maxShelters);
+  }
+
+  /**
+   * Compute distance from currentPoint to each shelter
+   * @param {LatLon} currentPoint - the point to find shelters nearest to
+   * @returns {Array<Object>} - the array of shelters with distance added
+  */
+  getShelterDistances (currentPoint) {
+    let all_shelters = this.getAllShelters();
+    return all_shelters.map((shelter) => {
+      return this.addDistanceToCurrentPoint(currentPoint, shelter);
+    });
+  }
+
+  /**
+   * Get all shelters available
+   * @returns {Array<Object>} - an array of all shelters
+  */
+  getAllShelters () {
+    let all_shelters = [];
+    this.locationData.forEach((shelter_list) => {
+      all_shelters = all_shelters.concat(Array.from(shelter_list));
+    });
+    return all_shelters;
+  }
+
+  /**
+   * Compute distance from currentPoint to given shelter
+   * @param {LatLon} currentPoint - location on globe to compute distance to
+   * @param {Object} shelter - shelter to compute distance to
+   * @returns {Object} - the shelter object with distance attribute added
+  */
+  addDistanceToCurrentPoint (currentPoint, shelter) {
+    const shelterLatLon = new LatLon(shelter.latitude, shelter.longitude);
+    shelter['distance'] = shelterLatLon.distanceTo(currentPoint);
+    return shelter;
   }
 
   /**
@@ -53,7 +96,7 @@ export default class SheltersFinder {
   zipCodesWithShelters () {
     return Array.from(this.locationData.keys());
   }
-  
+
   /**
    * Augment the zipcodes with zip information and zips in radius
    * @param {Array<string>} zips - the array of zipcodes to augment
@@ -113,7 +156,7 @@ export default class SheltersFinder {
     const inRadius = {};
     for (let idx in lookupZipCodes) {
       const zip = lookupZipCodes[idx].zip;
-      distances[zip] = shelterDistancesFromLookupZips[idx]; 
+      distances[zip] = shelterDistancesFromLookupZips[idx];
       inRadius[zip] = zipInMileRadiusFromShelter[idx];
     }
     return {
@@ -227,6 +270,60 @@ export default class SheltersFinder {
       if (resultString.length > 0) { messages.push(resultString) }
     }
     return messages;
+  }
+
+  /**
+   * Collect the shelters for the array of zip codes into an Array
+   * @param {Array<Object>} shelters - the shelters to be returned to user
+   * @returns {Array<string>} - the array of messages
+   */
+  buildReplyFromShelterList (shelters) {
+    const messages = [];
+    let resultString = `Found ${shelters.length} shelters near your location:`;
+    for (let shelter of shelters) {
+      const msg = this.constructMessageFromShelter(shelter);
+      if ((resultString + msg).length > 800) {
+        messages.push(resultString);
+        resultString = '';
+      }
+      resultString += msg;
+    }
+    if (resultString.length > 0) {
+      messages.push(resultString)
+    }
+    return messages;
+  }
+
+  /**
+   * Create distance message for a given shelter
+   * @param {Object} shelter - a shelter with distance to describe
+   * @returns {string} - Message for this shelter
+   */
+  constructMessageFromShelter (shelter) {
+    let dist = this.convertMetersToMiles(shelter['distance']);
+    return this.getStringRepresentationForShelter(shelter) +
+      `\n${dist < 1 ? 'Under 1' : `About ${dist}`}mi away`;
+  }
+
+  /**
+   * Convert from meters to miles
+   * @param {number} meters - a number in meters
+   * @returns {number} - that number in miles
+   */
+  convertMetersToMiles (meters) {
+    const milesToMeters = 1609.344, metersToMiles = 1.0 / milesToMeters;
+    let dist = metersToMiles * meters;
+    return (dist < 1.0 ? Math.ceil(dist * 10) / 10 : Math.ceil(dist));
+  }
+
+  /**
+   * Create string representation of a shelter
+   * @param {Object} shelterObj - The data for a shelter
+   * @returns {string} - A string representing relevant information to describe the shelter
+   */
+  getStringRepresentationForShelter (shelterObj) {
+     const { shelter, address, phone } = shelterObj;
+     return `\n${shelter}\n${address}${phone ? `\n${phone}` : ''}`;
   }
 }
 

--- a/lib/shelters_finder.js
+++ b/lib/shelters_finder.js
@@ -33,13 +33,17 @@ export default class SheltersFinder {
     if(sentZipCodes.length == 0) {
       return ['Sorry, I couldn\'t find any ZIP codes in your text message. Please try again.',];
     }
-    let test_zip_info = zipcodes.lookup(sentZipCodes[0]);
-    let test_zip = new LatLon(test_zip_info.latitude, test_zip_info.longitude);
-    let closest_shelters = this.findClosestNShelters(test_zip, this.nSheltersToFind);
-    let filtered_shelters = closest_shelters.filter(
-      shelter => this.convertMetersToMiles(shelter.distance) <= this.mileRadius
-    );
-    const messages = this.buildReplyFromShelterList(filtered_shelters);
+    var messages = [];
+    for (const zipCode of sentZipCodes) {
+      console.log(`Checking zip: ${zipCode}`)
+      let zipInfoToTest = zipcodes.lookup(zipCode);
+      let zipLatLon = new LatLon(zipInfoToTest.latitude, zipInfoToTest.longitude);
+      let closest_shelters = this.findClosestNShelters(zipLatLon, this.nSheltersToFind);
+      let filtered_shelters = closest_shelters.filter(
+        shelter => this.convertMetersToMiles(shelter.distance) <= this.mileRadius
+      );
+      messages = messages.concat(this.buildReplyFromShelterList(filtered_shelters, zipCode));
+    }
     return messages;
   }
 
@@ -106,11 +110,12 @@ export default class SheltersFinder {
   /**
    * Collect the shelters for the array of zip codes into an Array
    * @param {Array<Object>} shelters - the shelters to be returned to user
+   * @param {string} zipcode - zipcode
    * @returns {Array<string>} - the array of messages
    */
-  buildReplyFromShelterList (shelters) {
+  buildReplyFromShelterList (shelters, zipcode) {
     if (shelters.length == 0) {
-      return ["Sorry, I don't know about any shelters near your location. Please try again later!"];
+      return [`Sorry, I don't know about any shelters near ${zipcode}. Please try again later!`,];
     }
     const messages = [];
     let resultString = `Found ${shelters.length} shelters near your location:`;

--- a/lib/shelters_finder.js
+++ b/lib/shelters_finder.js
@@ -11,8 +11,9 @@ export default class SheltersFinder {
    * @param {number} mileRadius - the mile radius to use when finding nearby shelters
    * @returns {SheltersFinder} - the created SheltersFinder instance
    */
-  constructor (locationData, nSheltersToFind) {
+  constructor (locationData, mileRadius, nSheltersToFind) {
     this.locationData = locationData;
+    this.mileRadius = mileRadius;
     this.nSheltersToFind = nSheltersToFind;
   }
 
@@ -35,7 +36,10 @@ export default class SheltersFinder {
     let test_zip_info = zipcodes.lookup(sentZipCodes[0]);
     let test_zip = new LatLon(test_zip_info.latitude, test_zip_info.longitude);
     let closest_shelters = this.findClosestNShelters(test_zip, this.nSheltersToFind);
-    const messages = this.buildReplyFromShelterList(closest_shelters);
+    let filtered_shelters = closest_shelters.filter(
+      shelter => this.convertMetersToMiles(shelter.distance) <= this.mileRadius
+    );
+    const messages = this.buildReplyFromShelterList(filtered_shelters);
     return messages;
   }
 
@@ -105,6 +109,9 @@ export default class SheltersFinder {
    * @returns {Array<string>} - the array of messages
    */
   buildReplyFromShelterList (shelters) {
+    if (shelters.length == 0) {
+      return ["Sorry, I don't know about any shelters near your location. Please try again later!"];
+    }
     const messages = [];
     let resultString = `Found ${shelters.length} shelters near your location:`;
     for (let shelter of shelters) {

--- a/test/shelters_finder.test.js
+++ b/test/shelters_finder.test.js
@@ -1,4 +1,4 @@
-import SheltersFinder, { _dedupeArray, _deepCopyArray } from '../lib/shelters_finder';
+import SheltersFinder from '../lib/shelters_finder';
 import DataUpdater from '../lib/data_updater';
 import zipcodes from 'zipcodes';
 import LatLon from 'geodesy/latlon-ellipsoidal-vincenty';
@@ -14,7 +14,7 @@ const dataFixture = JSON.parse(
 describe('SheltersFinder', () => {
   describe('constructor', () => {
     it('creates a SheltersFinder object', () => {
-      const s = new SheltersFinder(new Map(), 5);
+      const s = new SheltersFinder(new Map(), 100, 20);
       expect(s).to.be.instanceOf(SheltersFinder);
     });
   });
@@ -23,364 +23,438 @@ describe('SheltersFinder', () => {
     it('updates the data with the provided object', () => {
       const startData = { 'some': 'data' };
       const updateData = { 'other': 'data' };
-      const s = new SheltersFinder(startData, 5);
+      const s = new SheltersFinder(startData, 100, 5);
       expect(s.locationData).to.deep.eql(startData);
       s.updateLocationData(updateData);
       expect(s.locationData).to.deep.eql(updateData);
     });
   });
 
-  describe('zipCodesWithShelters()', () => {
-    it('returns an array of zip codes', () => {
+  describe('findClosestNShelters', () => {
+    it('returns n closest shelters to given point and no more', () => {
       const d = new DataUpdater('some url');
       const locationData = d.extractGeoJsonData(dataFixture.features);
-      const s = new SheltersFinder(locationData, 5);
-      const zips = s.zipCodesWithShelters();
-      const expected = ['68850','68883','93555','78570','78559','78580','71301'];
-      for (let zip of expected) { expect(zips).includes(zip); }
-    });
-  });
-  
-  describe('augmentLookupZipCodes(...)', () => {
-    it('returns an array of objects with a zip property containing the zip code', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const zipcodes = ['70471', '70118'];
-      const augmentedZips = s.augmentLookupZipCodes(zipcodes);
-      for (let idx in augmentedZips) {
-        expect(augmentedZips[idx]).to.have.ownProperty('zip');
-        expect(augmentedZips[idx].zip).to.eql(zipcodes[idx]);
-      }
-    });
-    it('returns an array of objects with an info property matching interface zipcodes.ZipCode', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const ZipCodeType = zipcodes.lookup('70003').constructor;
-      const zips = ['70471', '70118'];
-      const augmentedZips = s.augmentLookupZipCodes(zips);
-      for (let idx in augmentedZips) {
-        expect(augmentedZips[idx]).to.have.ownProperty('info');
-        expect(augmentedZips[idx].info).to.be.instanceOf(ZipCodeType);
-      }
-    });
-    it('returns an array of objects with an latlon property of type LatLon', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const zipcodes = ['70471', '70118'];
-      const augmentedZips = s.augmentLookupZipCodes(zipcodes);
-      for (let idx in augmentedZips) {
-        expect(augmentedZips[idx]).to.have.ownProperty('latlon');
-        expect(augmentedZips[idx].latlon).to.be.instanceOf(LatLon);
-      }
-    });
-    it('returns an array of objects with an zipsInMileRadius property with an array of objects matching interface zipcodes.ZipCode', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const zips = ['70471', '70118'];
-      const augmentedZips = s.augmentLookupZipCodes(zips);
-      for (let idx in augmentedZips) {
-        expect(augmentedZips[idx]).to.have.ownProperty('zipsInMileRadius');
-        expect(augmentedZips[idx].zipsInMileRadius).to.be.an('array');
-        augmentedZips[idx].zipsInMileRadius.forEach((z) => {
-          expect(z).to.be.a('string');
-        });
-      }
-    });
-  });
-
-  describe('computeFoundShelters(...)', () => {
-    it('returns known zipcodes within the mile radius of each of the lookup zipcodes', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const lookups = ['70471', '70118'].map((z, _idx, _ary, sf = s) => {
-        return {
-          zipsInMileRadius: zipcodes.radius(z, sf.mileRadius)
-        };
-      });
-      const knowns = ['70124', '70003', '70116', '70471'];
-      const found = s.computeFoundShelters(lookups, knowns);
-      const expected = ['70124', '70116', '70471'];
-      for (let zip of expected) { expect(found).includes(zip); }
-    });
-  });
-
-  describe('augmentShelterRecord(...)', () => {
-    it('returns an object with property distances having keys lookups', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const shelter = dataFixture.features[0].properties;
-      const lookups = s.augmentLookupZipCodes(['70471', '70118']);
-      const augmented = s.augmentShelterRecord(shelter, lookups);
-      expect(augmented).to.have.ownProperty('distances');
-      expect(augmented.distances).to.be.an('object');
-      for (let l of lookups) {
-        expect(augmented.distances).to.have.ownProperty(l.zip);
-      }
-    });
-    it('returns an object with property inRadius having keys lookups', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const shelter = dataFixture.features[0].properties;
-      const lookups = s.augmentLookupZipCodes(['70471', '70118']);
-      const augmented = s.augmentShelterRecord(shelter, lookups);
-      expect(augmented).to.have.ownProperty('inRadius');
-      expect(augmented.inRadius).to.be.an('object');
-      for (let l of lookups) {
-        expect(augmented.inRadius).to.have.ownProperty(l.zip);
-      }
-    });
-    it('returns an object with array property message type string', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const shelter = dataFixture.features[0].properties;
-      const lookups = s.augmentLookupZipCodes(['70471', '70118']);
-      const augmented = s.augmentShelterRecord(shelter, lookups);
-      expect(augmented).to.have.ownProperty('message');
-      expect(augmented.message).to.be.a('string');
-    });
-  });
-
-  describe('collectShelters(...)', () => {
-    it('returns an array of objects ', () => {
-      const d = new DataUpdater('some_url');
-      const locationData = d.extractGeoJsonData(dataFixture.features);
-      const s = new SheltersFinder(locationData, 5);
-      const lookups = s.augmentLookupZipCodes(['68850', '71301']);
-      const knowns = s.zipCodesWithShelters();
-      const foundShelters = s.computeFoundShelters(lookups, knowns);
-      const collected = s.collectShelters(foundShelters, lookups);
-      const expected = Array.from(
-        JSON.parse('[{"accepting":"yes","shelter":"Lexington High School","address":"1308 N Adams St, Lexington, NE 68850, USA","city":"LEXINGTON","state":"NE","county":"Dawson County","zip":"68850","phone":null,"updated_by":null,"notes":null,"volunteer_needs":null,"longitude":-99.7487,"latitude":40.7868,"supply_needs":null,"source":"FEMA GeoServer, Shelter ID: 223259, Org ID: 121390, FORT KEARNEY CHAPTER","google_place_id":null,"special_needs":null,"id":2,"archived":false,"pets":"No","pets_notes":null,"needs":[],"updated_at":"2019-07-11T13:52:43-05:00","updatedAt":"2019-07-11T13:52:43-05:00","last_updated":"2019-07-11T13:52:43-05:00","cleanPhone":"badphone","shelterIndex":1},{"accepting":"yes","shelter":"Bolton Ave. Community Center","address":"226 Bolton Ave, Alexandria, LA 71301, USA","city":"ALEXANDRIA","state":"LA","county":"Rapides Parish","zip":"71301","phone":null,"updated_by":null,"notes":null,"volunteer_needs":null,"longitude":-92.458,"latitude":31.3076,"supply_needs":null,"source":"FEMA GeoServer, Shelter ID: 328703, Org ID: 121263, Central Louisiana Chapter","google_place_id":null,"special_needs":null,"id":8,"archived":false,"pets":"No","pets_notes":null,"needs":[],"updated_at":"2019-07-11T19:42:07-05:00","updatedAt":"2019-07-11T19:42:07-05:00","last_updated":"2019-07-11T19:42:07-05:00","cleanPhone":"badphone","shelterIndex":8}]')
-          .map(
-            (sh, _i, _a, sf = s, l = lookups) =>
-              sf.augmentShelterRecord(sh, l)
-          )
+      const s = new SheltersFinder(locationData, 100, 2);
+      const my_point = new LatLon(-99, 40);
+      const expected_names = Array(
+        "Pancho Maples FEMA Community Safe Room",
+        "Mercedes Saferoom/Community Recreation",
       );
-      expect(collected).to.be.an('array');
-      for (let shelter of expected) {
-        expect(collected).to.deep.include(shelter);
-      }
+      const result = s.findClosestNShelters(my_point, 2);
+//      console.log(`### Result = ${JSON.stringify(result)}`)
+      expect(result.map(s => s['shelter'])).to.deep.eql(expected_names);
     });
+   });
+
+ describe('getShelterDistances', () => {
+  it('adds distance to current point for all shelters', () => {
+      const d = new DataUpdater('some url');
+      const locationData = d.extractGeoJsonData(dataFixture.features);
+      const s = new SheltersFinder(locationData, 100, 5);
+      const my_point = new LatLon(-99, 40);
+      const expected_distances = Array(
+        15253092.814,
+        15243189.907,
+        14865529.136,
+        14865578.005,
+        13623054.565,
+        13620703.433,
+        13633121.898,
+        14116333.954,
+      );
+      const result = s.getShelterDistances(my_point);
+      expect(result.map(s => s['distance'])).to.deep.eql(expected_distances);
+  })
+ });
+
+  describe('findShelters', () => {
+    it('locates shelters within n miles of passed zipcodes', () => {
+        const d = new DataUpdater('some url');
+        const locationData = d.extractGeoJsonData(dataFixture.features);
+        const s = new SheltersFinder(locationData, 100, 2);
+        const expected_messages = Array(
+          "Found 2 shelters near your location:\nWillacy County Community Safe Room\n18508 US-77 Frontage Rd, Harlingen, TX 78552, USA\nAbout 15mi away\nPancho Maples FEMA Community Safe Room\n621 Pancho Maples Dr, La Feria, TX 78559, USA\nAbout 23mi away",
+          "Sorry, I don't know about any shelters near 70119. Please try again later!"
+        );
+        const input_zips = Array(78580, 70119);
+        const result = s.findShelters(input_zips);
+        expect(result).to.deep.eql(expected_messages);
+    })
+    it('truncates list of nearby shelters by distance', () => {
+        const d = new DataUpdater('some url');
+        const locationData = d.extractGeoJsonData(dataFixture.features);
+        const s = new SheltersFinder(locationData, 20, 6);
+        const expected_messages = Array(
+          "Found 1 shelters near your location:\nWillacy County Community Safe Room\n18508 US-77 Frontage Rd, Harlingen, TX 78552, USA\nAbout 15mi away"
+        );
+        const input_zips = [ 78580 ];
+        const result = s.findShelters(input_zips);
+        expect(result).to.deep.eql(expected_messages);
+    })
+    it('sends helpful message if no zipcodes passed', () => {
+        const d = new DataUpdater('some url');
+        const locationData = d.extractGeoJsonData(dataFixture.features);
+        const s = new SheltersFinder(locationData, 20, 6);
+        const expected_messages = Array(
+          'Sorry, I couldn\'t find any ZIP codes in your text message. Please try again.',
+        );
+        const input_zips = Array();
+        const result = s.findShelters(input_zips);
+        expect(result).to.deep.eql(expected_messages);
+    })
   });
 
-  describe('getInRadiusShelters(...)', () => {
-    it('returns in-radius shelters for the lookup as an array', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const shelters = [
-        { inRadius: { '70471': true, '70118': false } },
-        { inRadius: { '70471': true, '70118': true } },
-        { inRadius: { '70471': false, '70118': false } },
-        { inRadius: { '70471': false, '70118': true } }
-      ];
-      const expected_70471 = [
-        { inRadius: { '70471': true, '70118': false } },
-        { inRadius: { '70471': true, '70118': true } }
-      ];
-      for (let sh of expected_70471) {
-        expect(s.getInRadiusShelters(shelters, '70471')).to.deep.include(sh);
-      }
-      const expected_70118 = [
-        { inRadius: { '70471': true, '70118': true } },
-        { inRadius: { '70471': false, '70118': true } }
-      ];
-      for (let sh of expected_70118) {
-        expect(s.getInRadiusShelters(shelters, '70118')).to.deep.include(sh);
-      }
-    });
-  });
-
-  describe('sortSheltersByDistance(...)', () => {
-    it('sorts by ascending distance from the given lookup', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const shelters = [
-        { distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 } },
-        { distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 } },
-        { distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 } }
-      ];
-      const expected_70471 = [
-        { distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 } },
-        { distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 } },
-        { distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 } }
-      ];
-      for (let sh of expected_70471) {
-        expect(s.sortSheltersByDistance(shelters, '70471')).to.deep.include(sh);
-      }
-      const expected_70118 = [
-        { distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 } },
-        { distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 } },
-        { distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 } }
-      ];
-      for (let sh of expected_70118) {
-        expect(s.sortSheltersByDistance(shelters, '70118'))
-          .to.deep.include(sh);
-      }
-      const expected_70124 = [
-        { distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 } },
-        { distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 } },
-        { distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 } }
-      ];
-      for (let sh of expected_70124) {
-        expect(s.sortSheltersByDistance(shelters, '70124')).to.deep.include(sh);
-      }
-    });
-  });
-
-  describe('truncateShelterList(...)', () => {
-    it('truncates the array of shelters to the specified length', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const shelters = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-      let amt, x;
-      for (amt of [2, 3, 7, 12]) {
-        const truncated = s.truncateShelterList(shelters, amt);
-        const expected = Math.min(amt, shelters.length);
-        expect(truncated).to.be.an('array');
-        expect(truncated.length).to.eql(expected);
-        for (x = 0; x < expected; x++) {
-          expect(truncated[x]).to.eql(shelters[x]);
-        }
-      }
-    });
-  });
-
-  describe('sortedShelterListsByLookupZip', () => {
-    it('returns filtered, sorted and truncated lists of shelters for each lookup zipcode', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const shelters = [
-        {
-          distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 },
-          inRadius: { '70471': false, '70118': true, '70124': true }
-        },
-        {
-          distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 },
-          inRadius:  { '70471': true, '70118': true, '70124': true }
-        },
-        {
-          distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 },
-          inRadius:  { '70471': true, '70118': true, '70124': false }
-        },
-        {
-          distances: { '70471': 5.3, '70118': 7.0, '70124': 8.1 },
-          inRadius:  { '70471': false, '70118': false, '70124': false }
-        }
-      ];
-      const lookups = [
-        { zip: '70471' },
-        { zip: '70118' },
-        { zip: '70124' }
-      ];
-      const expected = {
-        '70471': [
-          {
-            distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 },
-            inRadius: { '70471': true, '70118': true, '70124': true }
-          },
-          {
-            distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 },
-            inRadius: { '70471': true, '70118': true, '70124': false }
-          }
-        ],
-        '70118': [
-          {
-            distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 },
-            inRadius: { '70471': true, '70118': true, '70124': false }
-          },
-          {
-            distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 },
-            inRadius: { '70471': true, '70118': true, '70124': true }
-          }
-        ],
-        '70124': [
-          {
-            distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 },
-            inRadius: { '70471': false, '70118': true, '70124': true }
-          },
-          {
-            distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 },
-            inRadius: { '70471': true, '70118': true, '70124': true }
-          }
-        ]
-      };
-      const lists = s.sortSheltersByDistance(shelters, lookups, 2);
-      for (let lookup of lookups) {
-        expect(lists[lookup]).to.deep.eql(expected[lookup]);
-      }
-    });
-  });
-
-  describe('buildMessages(...)', () => {
-    it('generates an array of messages', () => {
-      const s = new SheltersFinder(new Map(), 5);
-      const sorts = {
-        '70471': [
-          {
-            distances: { '70471': 418.4, '70118': 4506.2, '70124': 4667.1 },
-            message: '\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471'
-          },
-          {
-            distances: { '70471': 5310.8, '70118': 1609.3, '70124': 15449.7 },
-            message: '\n\nSHELTER NUMBER TWO\n123 Any Street, New Orleans, LA 70118'
-          }
-        ],
-        '70118': [
-          {
-            distances: { '70471': 5310.8, '70118': 1609.3, '70124': 15449.7 },
-            message: '\n\nSHELTER NUMBER TWO\n123 Any Street, New Orleans, LA 70118'
-          },
-          {
-            distances: { '70471': 418.4, '70118': 4506.2, '70124': 4667.1 },
-            message: '\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471'
-          }
-        ],
-        '70124': [
-          {
-            distances: { '70471': 9012.3, '70118': 6920.2, '70124': 3379.6 },
-            message: '\n\nSHELTER NUMBER THREE\n456 Other Street, New Orleans, LA 70123'
-          },
-          {
-            distances: { '70471': 418.4, '70118': 4506.2, '70124': 4667.1 },
-            message: '\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471'
-          }
-        ]
-      };
-      const expected = [
-        'Found 2 shelters near 70471:\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471\nUnder 1mi away\n\nSHELTER NUMBER TWO\n123 Any Street, New Orleans, LA 70118\nAbout 4mi away',
-        'Found 2 shelters near 70118:\n\nSHELTER NUMBER TWO\n123 Any Street, New Orleans, LA 70118\nAbout 1mi away\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471\nAbout 3mi away',
-        'Found 2 shelters near 70124:\n\nSHELTER NUMBER THREE\n456 Other Street, New Orleans, LA 70123\nAbout 3mi away\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471\nAbout 3mi away'
-      ];
-      for (let message of expected) {
-        expect(s.buildMessages(sorts)).to.deep.include(message);
-      }
-    });
-  });
-
-  describe('helpers', () => {
-    describe('_dedupeArray(...)', () => {
-      it('dedupes an array of objects by key', () => {
-        const arr = [
-          { a: 0, b: 1, c: 2 },
-          { a: 0, b: 3, c: 2 },
-          { a: 0, b: 1, c: 8 },
-          { a: 1, b: 1, c: 8 }
-        ];
-        const expected = {
-          a: [
-            { a: 0, b: 1, c: 2 },
-            { a: 1, b: 1, c: 8 }
-          ],
-          b: [
-            { a: 0, b: 1, c: 2 },
-            { a: 0, b: 3, c: 2 },
-          ],
-          c: [
-            { a: 0, b: 1, c: 2 },
-            { a: 0, b: 1, c: 8 }
-          ]
-        };
-        for (let key in expected) {
-          expect(_dedupeArray(arr, key)).to.deep.equal(expected[key]);
-        }
-      });
-    });
-
-    describe('_deepCopyArray(...)', () => {
-      it('deep-copies an array of arbitrary data types', () => {
-        const arr = [0, 'string', false, ['another', 'array', 5], {
-          some: 'object', of: 'structured', data: [9, 3, 2, 4, 1]
-        }, 5, [ { a: 0, b: 1, c: 2 }, { a: 0, b: 1, c: 8 } ]];
-        expect(_deepCopyArray(arr)).to.deep.equal(arr);
-      });
-    });
-  });
+//  describe('zipCodesWithShelters()', () => {
+//    it('returns an array of zip codes', () => {
+//      const d = new DataUpdater('some url');
+//      const locationData = d.extractGeoJsonData(dataFixture.features);
+//      const s = new SheltersFinder(locationData, 5);
+//      const zips = s.zipCodesWithShelters();
+//      const expected = ['68850','68883','93555','78570','78559','78580','71301'];
+//      for (let zip of expected) { expect(zips).includes(zip); }
+//    });
+//  });
+//
+//  describe('augmentLookupZipCodes(...)', () => {
+//    it('returns an array of objects with a zip property containing the zip code', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const zipcodes = ['70471', '70118'];
+//      const augmentedZips = s.augmentLookupZipCodes(zipcodes);
+//      for (let idx in augmentedZips) {
+//        expect(augmentedZips[idx]).to.have.ownProperty('zip');
+//        expect(augmentedZips[idx].zip).to.eql(zipcodes[idx]);
+//      }
+//    });
+//    it('returns an array of objects with an info property matching interface zipcodes.ZipCode', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const ZipCodeType = zipcodes.lookup('70003').constructor;
+//      const zips = ['70471', '70118'];
+//      const augmentedZips = s.augmentLookupZipCodes(zips);
+//      for (let idx in augmentedZips) {
+//        expect(augmentedZips[idx]).to.have.ownProperty('info');
+//        expect(augmentedZips[idx].info).to.be.instanceOf(ZipCodeType);
+//      }
+//    });
+//    it('returns an array of objects with an latlon property of type LatLon', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const zipcodes = ['70471', '70118'];
+//      const augmentedZips = s.augmentLookupZipCodes(zipcodes);
+//      for (let idx in augmentedZips) {
+//        expect(augmentedZips[idx]).to.have.ownProperty('latlon');
+//        expect(augmentedZips[idx].latlon).to.be.instanceOf(LatLon);
+//      }
+//    });
+//    it('returns an array of objects with an zipsInMileRadius property with an array of objects matching interface zipcodes.ZipCode', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const zips = ['70471', '70118'];
+//      const augmentedZips = s.augmentLookupZipCodes(zips);
+//      for (let idx in augmentedZips) {
+//        expect(augmentedZips[idx]).to.have.ownProperty('zipsInMileRadius');
+//        expect(augmentedZips[idx].zipsInMileRadius).to.be.an('array');
+//        augmentedZips[idx].zipsInMileRadius.forEach((z) => {
+//          expect(z).to.be.a('string');
+//        });
+//      }
+//    });
+//  });
+//
+//  describe('computeFoundShelters(...)', () => {
+//    it('returns known zipcodes within the mile radius of each of the lookup zipcodes', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const lookups = ['70471', '70118'].map((z, _idx, _ary, sf = s) => {
+//        return {
+//          zipsInMileRadius: zipcodes.radius(z, sf.mileRadius)
+//        };
+//      });
+//      const knowns = ['70124', '70003', '70116', '70471'];
+//      const found = s.computeFoundShelters(lookups, knowns);
+//      const expected = ['70124', '70116', '70471'];
+//      for (let zip of expected) { expect(found).includes(zip); }
+//    });
+//  });
+//
+//  describe('augmentShelterRecord(...)', () => {
+//    it('returns an object with property distances having keys lookups', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const shelter = dataFixture.features[0].properties;
+//      const lookups = s.augmentLookupZipCodes(['70471', '70118']);
+//      const augmented = s.augmentShelterRecord(shelter, lookups);
+//      expect(augmented).to.have.ownProperty('distances');
+//      expect(augmented.distances).to.be.an('object');
+//      for (let l of lookups) {
+//        expect(augmented.distances).to.have.ownProperty(l.zip);
+//      }
+//    });
+//    it('returns an object with property inRadius having keys lookups', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const shelter = dataFixture.features[0].properties;
+//      const lookups = s.augmentLookupZipCodes(['70471', '70118']);
+//      const augmented = s.augmentShelterRecord(shelter, lookups);
+//      expect(augmented).to.have.ownProperty('inRadius');
+//      expect(augmented.inRadius).to.be.an('object');
+//      for (let l of lookups) {
+//        expect(augmented.inRadius).to.have.ownProperty(l.zip);
+//      }
+//    });
+//    it('returns an object with array property message type string', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const shelter = dataFixture.features[0].properties;
+//      const lookups = s.augmentLookupZipCodes(['70471', '70118']);
+//      const augmented = s.augmentShelterRecord(shelter, lookups);
+//      expect(augmented).to.have.ownProperty('message');
+//      expect(augmented.message).to.be.a('string');
+//    });
+//  });
+//
+//  describe('collectShelters(...)', () => {
+//    it('returns an array of objects ', () => {
+//      const d = new DataUpdater('some_url');
+//      const locationData = d.extractGeoJsonData(dataFixture.features);
+//      const s = new SheltersFinder(locationData, 5);
+//      const lookups = s.augmentLookupZipCodes(['68850', '71301']);
+//      const knowns = s.zipCodesWithShelters();
+//      const foundShelters = s.computeFoundShelters(lookups, knowns);
+//      const collected = s.collectShelters(foundShelters, lookups);
+//      const expected = Array.from(
+//        JSON.parse('[{"accepting":"yes","shelter":"Lexington High School","address":"1308 N Adams St, Lexington, NE 68850, USA","city":"LEXINGTON","state":"NE","county":"Dawson County","zip":"68850","phone":null,"updated_by":null,"notes":null,"volunteer_needs":null,"longitude":-99.7487,"latitude":40.7868,"supply_needs":null,"source":"FEMA GeoServer, Shelter ID: 223259, Org ID: 121390, FORT KEARNEY CHAPTER","google_place_id":null,"special_needs":null,"id":2,"archived":false,"pets":"No","pets_notes":null,"needs":[],"updated_at":"2019-07-11T13:52:43-05:00","updatedAt":"2019-07-11T13:52:43-05:00","last_updated":"2019-07-11T13:52:43-05:00","cleanPhone":"badphone","shelterIndex":1},{"accepting":"yes","shelter":"Bolton Ave. Community Center","address":"226 Bolton Ave, Alexandria, LA 71301, USA","city":"ALEXANDRIA","state":"LA","county":"Rapides Parish","zip":"71301","phone":null,"updated_by":null,"notes":null,"volunteer_needs":null,"longitude":-92.458,"latitude":31.3076,"supply_needs":null,"source":"FEMA GeoServer, Shelter ID: 328703, Org ID: 121263, Central Louisiana Chapter","google_place_id":null,"special_needs":null,"id":8,"archived":false,"pets":"No","pets_notes":null,"needs":[],"updated_at":"2019-07-11T19:42:07-05:00","updatedAt":"2019-07-11T19:42:07-05:00","last_updated":"2019-07-11T19:42:07-05:00","cleanPhone":"badphone","shelterIndex":8}]')
+//          .map(
+//            (sh, _i, _a, sf = s, l = lookups) =>
+//              sf.augmentShelterRecord(sh, l)
+//          )
+//      );
+//      expect(collected).to.be.an('array');
+//      for (let shelter of expected) {
+//        expect(collected).to.deep.include(shelter);
+//      }
+//    });
+//  });
+//
+//  describe('getInRadiusShelters(...)', () => {
+//    it('returns in-radius shelters for the lookup as an array', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const shelters = [
+//        { inRadius: { '70471': true, '70118': false } },
+//        { inRadius: { '70471': true, '70118': true } },
+//        { inRadius: { '70471': false, '70118': false } },
+//        { inRadius: { '70471': false, '70118': true } }
+//      ];
+//      const expected_70471 = [
+//        { inRadius: { '70471': true, '70118': false } },
+//        { inRadius: { '70471': true, '70118': true } }
+//      ];
+//      for (let sh of expected_70471) {
+//        expect(s.getInRadiusShelters(shelters, '70471')).to.deep.include(sh);
+//      }
+//      const expected_70118 = [
+//        { inRadius: { '70471': true, '70118': true } },
+//        { inRadius: { '70471': false, '70118': true } }
+//      ];
+//      for (let sh of expected_70118) {
+//        expect(s.getInRadiusShelters(shelters, '70118')).to.deep.include(sh);
+//      }
+//    });
+//  });
+//
+//  describe('sortSheltersByDistance(...)', () => {
+//    it('sorts by ascending distance from the given lookup', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const shelters = [
+//        { distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 } },
+//        { distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 } },
+//        { distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 } }
+//      ];
+//      const expected_70471 = [
+//        { distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 } },
+//        { distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 } },
+//        { distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 } }
+//      ];
+//      for (let sh of expected_70471) {
+//        expect(s.sortSheltersByDistance(shelters, '70471')).to.deep.include(sh);
+//      }
+//      const expected_70118 = [
+//        { distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 } },
+//        { distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 } },
+//        { distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 } }
+//      ];
+//      for (let sh of expected_70118) {
+//        expect(s.sortSheltersByDistance(shelters, '70118'))
+//          .to.deep.include(sh);
+//      }
+//      const expected_70124 = [
+//        { distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 } },
+//        { distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 } },
+//        { distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 } }
+//      ];
+//      for (let sh of expected_70124) {
+//        expect(s.sortSheltersByDistance(shelters, '70124')).to.deep.include(sh);
+//      }
+//    });
+//  });
+//
+//  describe('truncateShelterList(...)', () => {
+//    it('truncates the array of shelters to the specified length', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const shelters = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+//      let amt, x;
+//      for (amt of [2, 3, 7, 12]) {
+//        const truncated = s.truncateShelterList(shelters, amt);
+//        const expected = Math.min(amt, shelters.length);
+//        expect(truncated).to.be.an('array');
+//        expect(truncated.length).to.eql(expected);
+//        for (x = 0; x < expected; x++) {
+//          expect(truncated[x]).to.eql(shelters[x]);
+//        }
+//      }
+//    });
+//  });
+//
+//  describe('sortedShelterListsByLookupZip', () => {
+//    it('returns filtered, sorted and truncated lists of shelters for each lookup zipcode', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const shelters = [
+//        {
+//          distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 },
+//          inRadius: { '70471': false, '70118': true, '70124': true }
+//        },
+//        {
+//          distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 },
+//          inRadius:  { '70471': true, '70118': true, '70124': true }
+//        },
+//        {
+//          distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 },
+//          inRadius:  { '70471': true, '70118': true, '70124': false }
+//        },
+//        {
+//          distances: { '70471': 5.3, '70118': 7.0, '70124': 8.1 },
+//          inRadius:  { '70471': false, '70118': false, '70124': false }
+//        }
+//      ];
+//      const lookups = [
+//        { zip: '70471' },
+//        { zip: '70118' },
+//        { zip: '70124' }
+//      ];
+//      const expected = {
+//        '70471': [
+//          {
+//            distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 },
+//            inRadius: { '70471': true, '70118': true, '70124': true }
+//          },
+//          {
+//            distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 },
+//            inRadius: { '70471': true, '70118': true, '70124': false }
+//          }
+//        ],
+//        '70118': [
+//          {
+//            distances: { '70471': 3.3, '70118': 1.0, '70124': 9.6 },
+//            inRadius: { '70471': true, '70118': true, '70124': false }
+//          },
+//          {
+//            distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 },
+//            inRadius: { '70471': true, '70118': true, '70124': true }
+//          }
+//        ],
+//        '70124': [
+//          {
+//            distances: { '70471': 5.6, '70118': 4.3, '70124': 2.1 },
+//            inRadius: { '70471': false, '70118': true, '70124': true }
+//          },
+//          {
+//            distances: { '70471': 1.2, '70118': 2.8, '70124': 2.9 },
+//            inRadius: { '70471': true, '70118': true, '70124': true }
+//          }
+//        ]
+//      };
+//      const lists = s.sortSheltersByDistance(shelters, lookups, 2);
+//      for (let lookup of lookups) {
+//        expect(lists[lookup]).to.deep.eql(expected[lookup]);
+//      }
+//    });
+//  });
+//
+//  describe('buildMessages(...)', () => {
+//    it('generates an array of messages', () => {
+//      const s = new SheltersFinder(new Map(), 5);
+//      const sorts = {
+//        '70471': [
+//          {
+//            distances: { '70471': 418.4, '70118': 4506.2, '70124': 4667.1 },
+//            message: '\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471'
+//          },
+//          {
+//            distances: { '70471': 5310.8, '70118': 1609.3, '70124': 15449.7 },
+//            message: '\n\nSHELTER NUMBER TWO\n123 Any Street, New Orleans, LA 70118'
+//          }
+//        ],
+//        '70118': [
+//          {
+//            distances: { '70471': 5310.8, '70118': 1609.3, '70124': 15449.7 },
+//            message: '\n\nSHELTER NUMBER TWO\n123 Any Street, New Orleans, LA 70118'
+//          },
+//          {
+//            distances: { '70471': 418.4, '70118': 4506.2, '70124': 4667.1 },
+//            message: '\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471'
+//          }
+//        ],
+//        '70124': [
+//          {
+//            distances: { '70471': 9012.3, '70118': 6920.2, '70124': 3379.6 },
+//            message: '\n\nSHELTER NUMBER THREE\n456 Other Street, New Orleans, LA 70123'
+//          },
+//          {
+//            distances: { '70471': 418.4, '70118': 4506.2, '70124': 4667.1 },
+//            message: '\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471'
+//          }
+//        ]
+//      };
+//      const expected = [
+//        'Found 2 shelters near 70471:\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471\nUnder 1mi away\n\nSHELTER NUMBER TWO\n123 Any Street, New Orleans, LA 70118\nAbout 4mi away',
+//        'Found 2 shelters near 70118:\n\nSHELTER NUMBER TWO\n123 Any Street, New Orleans, LA 70118\nAbout 1mi away\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471\nAbout 3mi away',
+//        'Found 2 shelters near 70124:\n\nSHELTER NUMBER THREE\n456 Other Street, New Orleans, LA 70123\nAbout 3mi away\n\nSHELTER NUMBER ONE\n123 Any Street, Mandeville, LA 70471\nAbout 3mi away'
+//      ];
+//      for (let message of expected) {
+//        expect(s.buildMessages(sorts)).to.deep.include(message);
+//      }
+//    });
+//  });
+//
+//  describe('helpers', () => {
+//    describe('_dedupeArray(...)', () => {
+//      it('dedupes an array of objects by key', () => {
+//        const arr = [
+//          { a: 0, b: 1, c: 2 },
+//          { a: 0, b: 3, c: 2 },
+//          { a: 0, b: 1, c: 8 },
+//          { a: 1, b: 1, c: 8 }
+//        ];
+//        const expected = {
+//          a: [
+//            { a: 0, b: 1, c: 2 },
+//            { a: 1, b: 1, c: 8 }
+//          ],
+//          b: [
+//            { a: 0, b: 1, c: 2 },
+//            { a: 0, b: 3, c: 2 },
+//          ],
+//          c: [
+//            { a: 0, b: 1, c: 2 },
+//            { a: 0, b: 1, c: 8 }
+//          ]
+//        };
+//        for (let key in expected) {
+//          expect(_dedupeArray(arr, key)).to.deep.equal(expected[key]);
+//        }
+//      });
+//    });
+//
+//    describe('_deepCopyArray(...)', () => {
+//      it('deep-copies an array of arbitrary data types', () => {
+//        const arr = [0, 'string', false, ['another', 'array', 5], {
+//          some: 'object', of: 'structured', data: [9, 3, 2, 4, 1]
+//        }, 5, [ { a: 0, b: 1, c: 2 }, { a: 0, b: 1, c: 8 } ]];
+//        expect(_deepCopyArray(arr)).to.deep.equal(arr);
+//      });
+//    });
+//  });
 });


### PR DESCRIPTION
Refactoring the find shelters functionality to use distance from a given point. This is currently going to reduce efficiency but will enable using geocoding to get the closest shelters to any given point, not just the center of a zip code.

This code is definitely less performant as number of shelters goes up but we can add in some optimizations in the future so we're only checking a subset of zip codes first, but didn't include that in the initial version.

Currently posting as a draft because I know there are some changes to the overall functionality that haven't been discussed yet and so am gonna hold off on tests until I see people are happy with this proposed change in interface.